### PR TITLE
refactor: logic structure on if-else-if jwt

### DIFF
--- a/10-node-authentication/server.js
+++ b/10-node-authentication/server.js
@@ -63,25 +63,23 @@ apiRouter.post('/authenticate', function(req, res) {
       var validPassword = user.comparePassword(req.body.password);
       if (!validPassword) {
         res.json({ success: false, message: 'Authentication failed. Wrong password.' });
-      } else {
+      } 
 
-        // if user is found and password is right
-        // create a token
-        var token = jwt.sign({
-        	name: user.name,
-        	username: user.username
-        }, superSecret, {
-          expiresInMinutes: 1440 // expires in 24 hours
-        });
+	// if user is found and password is right
+	// create a token
+	var token = jwt.sign({
+		name: user.name,
+		username: user.username
+	}, superSecret, {
+	  expiresInMinutes: 1440 // expires in 24 hours
+	});
 
-        // return the information including token as JSON
-        res.json({
-          success: true,
-          message: 'Enjoy your token!',
-          token: token
-        });
-      }   
-
+	// return the information including token as JSON
+	res.json({
+	  success: true,
+	  message: 'Enjoy your token!',
+	  token: token
+	});
     }
 
   });


### PR DESCRIPTION
Hello @sevilayha,

Thanks again for being swift in getting back to me on errata submissions --appreciate it!

I wanted to highlight a quick refactor that perhaps you have considered but debated on. The flow of logic when it comes to the authentication API route seems to be out-of-place with the addition of an else-block. That is, you consider the validation of a user and the password that is sent via POST. 

Using the else-block implies a fall-back on the logic the precedes it --whether that passes or fails. It would be more straightforward to withhold this block as it is already implied that the proceeding statements will execute in case of success.
