### PR TITLE
Update to Gulpfile.js to fix memory leak issue.

### DIFF
--- a/19-mean-workflow/gulpfile.js
+++ b/19-mean-workflow/gulpfile.js
@@ -61,7 +61,6 @@ gulp.task('nodemon', function() {
     ext: 'js less html'
   })
     .on('start', ['watch'])
-    .on('change', ['watch'])
     .on('restart', function() {
       console.log('Restarted!');
     });


### PR DESCRIPTION
See Issue #32.

On change function is redundant and actually causes memory leaks once called enough.
